### PR TITLE
アクセス認可設定の修正

### DIFF
--- a/src/main/java/oit/is/chisakiken/hondaboard/security/AuthConfiguration.java
+++ b/src/main/java/oit/is/chisakiken/hondaboard/security/AuthConfiguration.java
@@ -32,7 +32,7 @@ public class AuthConfiguration extends WebSecurityConfigurerAdapter {
         // Spring Securityのフォームを利用してログインを行う
         http.formLogin().loginProcessingUrl("/login").loginPage("/");
         // 非ログインユーザ許可
-        http.authorizeRequests().antMatchers("/", "/register","/event/all").permitAll();
+        http.authorizeRequests().antMatchers("/", "/register","/event/all","/chatpage/sse").permitAll();
         http.authorizeRequests().antMatchers(HttpMethod.GET,"/chatpage").permitAll();
 
         http.authorizeRequests().anyRequest().authenticated();

--- a/src/main/java/oit/is/chisakiken/hondaboard/security/AuthConfiguration.java
+++ b/src/main/java/oit/is/chisakiken/hondaboard/security/AuthConfiguration.java
@@ -30,7 +30,7 @@ public class AuthConfiguration extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
 
         // Spring Securityのフォームを利用してログインを行う
-        http.formLogin().loginProcessingUrl("/login").loginPage("/");
+        http.formLogin().loginProcessingUrl("/login").loginPage("/").defaultSuccessUrl("/userpage", true);
         // 非ログインユーザ許可
         http.authorizeRequests().antMatchers("/", "/register","/event/all","/chatpage/sse").permitAll();
         http.authorizeRequests().antMatchers(HttpMethod.GET,"/chatpage").permitAll();

--- a/src/main/java/oit/is/chisakiken/hondaboard/security/AuthConfiguration.java
+++ b/src/main/java/oit/is/chisakiken/hondaboard/security/AuthConfiguration.java
@@ -2,7 +2,9 @@ package oit.is.chisakiken.hondaboard.security;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -16,6 +18,11 @@ public class AuthConfiguration extends WebSecurityConfigurerAdapter {
         return new BCryptPasswordEncoder();
     }
 
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().antMatchers("/favicon.ico");
+    }
+
     /**
      * 認証されたユーザがどこにアクセスできるか（認可処理）
      */
@@ -23,8 +30,13 @@ public class AuthConfiguration extends WebSecurityConfigurerAdapter {
     protected void configure(HttpSecurity http) throws Exception {
 
         // Spring Securityのフォームを利用してログインを行う
-        http.formLogin().loginProcessingUrl("/login").loginPage("/login");
-        http.authorizeRequests().antMatchers("/userpage").authenticated();
+        http.formLogin().loginProcessingUrl("/login").loginPage("/");
+        // 非ログインユーザ許可
+        http.authorizeRequests().antMatchers("/", "/register","/event/all").permitAll();
+        http.authorizeRequests().antMatchers(HttpMethod.GET,"/chatpage").permitAll();
+
+        http.authorizeRequests().anyRequest().authenticated();
+
         http.csrf().disable();
         http.headers().frameOptions().disable();
 


### PR DESCRIPTION
アクセス認可設定の修正

非ログインユーザの許可範囲をホワイトリスト式にする。

---

非ログインユーザ許可
- `/`  :トップページ
- `/register` : ユーザ登録ページ
- `/event/all`:トップページのイベント取得
- `GET /chatpage` : チャット閲覧用
- `/chatpage/sse` : チャット非同期更新